### PR TITLE
Simulate delay on local

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,15 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 
 // Use Routes
-app.use('/api', api)
+if (process.env.NODE_ENV === 'development') {
+  // Simulate delay while accessing db on local
+  const addDelay = async next => {
+    await setTimeout(() => next(), 2000)
+  }
+  app.use('/api', (req, res, next) => addDelay(next), api)
+} else {
+  app.use('/api', api)
+}
 
 app.use((req, res) => {
   res.status(404).json({ error: 'Route not found' })


### PR DESCRIPTION
Add delay to simulate slow network access or cross-server API access

Before

<img width="692" alt="Screenshot 2021-11-08 at 2 11 12 PM" src="https://user-images.githubusercontent.com/38921817/140711757-8f6bcd1f-5693-409d-9c6e-bd89df20986a.png">

After

<img width="691" alt="Screenshot 2021-11-08 at 2 11 40 PM" src="https://user-images.githubusercontent.com/38921817/140711786-860bd8d7-ccca-4aea-a17b-d9c0da20d01a.png">
